### PR TITLE
chore: wrong repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
       }
     }
   },
-  "repository": "salesforcecli/plugin-template",
+  "repository": "salesforcecli/plugin-trust",
   "scripts": {
     "build": "sf-build",
     "clean": "sf-clean",


### PR DESCRIPTION
### What does this PR do?
sets the right repository so dependabot automerges looks in the right place via github API 
### What issues does this PR fix or reference?
@W-8776229@