### PR TITLE
fix: install plugin-trust as an executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "validate a digital signature for a npm package",
   "version": "1.0.5",
   "author": "Salesforce",
+  "bin": {
+    "sf-trust": "bin/run"
+  },
   "bugs": "https://github.com/forcedotcom/cli/issues",
   "dependencies": {
     "@oclif/config": "^1.17.0",
@@ -56,6 +59,7 @@
     "node": ">=12.0.0"
   },
   "files": [
+    "bin",
     "/lib",
     "/messages",
     "/oclif.manifest.json"


### PR DESCRIPTION
### What does this PR do?
Allows using plugin-trust as a standalone binary `sf-trust`.

### What issues does this PR fix or reference?
@W-9496922@