### PR TITLE
fix: use tag when getting npm meta

### DIFF
--- a/src/lib/installationVerification.ts
+++ b/src/lib/installationVerification.ts
@@ -345,7 +345,7 @@ export class InstallationVerification implements Verifier {
       ? `@${this.pluginNpmName.scope}/${this.pluginNpmName.name}`
       : this.pluginNpmName.name;
 
-    const npmModule = new NpmModule(npmShowModule);
+    const npmModule = new NpmModule(npmShowModule, this.pluginNpmName.tag);
     const npmMetadata = npmModule.show(npmRegistry.href);
     logger.debug('retrieveNpmMeta | Found npm meta information.');
     if (!npmMetadata.versions) {


### PR DESCRIPTION
### What does this PR do?

Include the provided tag when getting npm meta from `npm show`

### What issues does this PR fix or reference?
@W-9911065@