### PR TITLE
fix: improve error messages when shelling out npm commands

### DIFF
--- a/src/lib/installationVerification.ts
+++ b/src/lib/installationVerification.ts
@@ -316,7 +316,7 @@ export class InstallationVerification implements Verifier {
       npmMeta.tarballLocalPath = path.join(this.getCachePath(), tarBallFile.name);
     } catch (err) {
       logger.debug(err);
-      throw new SfdxError(err, 'ShellExecError');
+      throw err;
     }
 
     return npmMeta;

--- a/test/lib/npmCommand.test.ts
+++ b/test/lib/npmCommand.test.ts
@@ -317,7 +317,7 @@ describe('should run npm commands with execution errors', () => {
       new NpmModule(MODULE_NAME, MODULE_VERSION, __dirname).pack(DEFAULT_REGISTRY, { cwd: CACHE_PATH });
       fail('Error');
     } catch (error) {
-      expect(error.code).to.equal('ShellExecError');
+      expect(error.code).to.equal('NpmError');
     }
   });
 });
@@ -363,15 +363,6 @@ describe('should run npm commands with parse errors', () => {
     try {
       const npmMetadata = new NpmModule(MODULE_NAME, MODULE_VERSION, __dirname).show(DEFAULT_REGISTRY);
       expect(npmMetadata).to.be.undefined;
-      fail('Error');
-    } catch (error) {
-      expect(error.code).to.equal('ShellParseError');
-    }
-  });
-
-  it('Runs the pack command', () => {
-    try {
-      new NpmModule(MODULE_NAME, MODULE_VERSION, __dirname).pack(DEFAULT_REGISTRY, { cwd: CACHE_PATH });
       fail('Error');
     } catch (error) {
       expect(error.code).to.equal('ShellParseError');


### PR DESCRIPTION
### What does this PR do?
Fix empty error reports when an npm command (`show`, `pack`) fails. 

`npm show` doesn't find a specific package version
```
Checking for digital signature.
ERROR running plugins:trust:verify:  Failed to find @salesforce/plugin-source@1.2.5 in the registry
```

Possible race condition scenario:
1. `npm show` finds @salesforce/plugin-source@1.2.5, then
2. `npm pack` fails to find it:
```
ERROR running plugins:trust:verify:  Failed to fetch tarball from the registry:
npm ERR! code ETARGET
npm ERR! notarget No matching version found for @salesforce/plugin-source@1.2.5.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/cdominguez/.npm/_logs/2021-10-25T19_25_40_533Z-debug.log
```
### What issues does this PR fix or reference?
@W-10065192@