### PR TITLE
fix: poll `npm pack` until tarball is available

### DIFF
--- a/src/lib/installationVerification.ts
+++ b/src/lib/installationVerification.ts
@@ -308,7 +308,7 @@ export class InstallationVerification implements Verifier {
     try {
       await fs.mkdirp(this.getCachePath());
       const npmModule = new NpmModule(npmMeta.moduleName, npmMeta.version, this.config.cliRoot);
-      await npmModule.fetchTarbarll(getNpmRegistry().href, {
+      await npmModule.fetchTarball(getNpmRegistry().href, {
         cwd: this.getCachePath(),
       });
       const tarBallFile = fs

--- a/src/lib/installationVerification.ts
+++ b/src/lib/installationVerification.ts
@@ -307,7 +307,8 @@ export class InstallationVerification implements Verifier {
     // Make sure the cache path exists.
     try {
       await fs.mkdirp(this.getCachePath());
-      new NpmModule(npmMeta.moduleName, npmMeta.version, this.config.cliRoot).pack(getNpmRegistry().href, {
+      const npmModule = new NpmModule(npmMeta.moduleName, npmMeta.version, this.config.cliRoot);
+      await npmModule.fetchTarbarll(getNpmRegistry().href, {
         cwd: this.getCachePath(),
       });
       const tarBallFile = fs

--- a/src/lib/installationVerification.ts
+++ b/src/lib/installationVerification.ts
@@ -316,7 +316,7 @@ export class InstallationVerification implements Verifier {
       npmMeta.tarballLocalPath = path.join(this.getCachePath(), tarBallFile.name);
     } catch (err) {
       logger.debug(err);
-      throw new SfdxError(err, 'ShellExecError');
+      throw err;
     }
 
     return npmMeta;

--- a/src/lib/npmCommand.ts
+++ b/src/lib/npmCommand.ts
@@ -188,7 +188,7 @@ export class NpmModule {
     return;
   }
 
-  public async fetchTarbarll(registry: string, options?: shelljs.ExecOptions): Promise<void> {
+  public async fetchTarball(registry: string, options?: shelljs.ExecOptions): Promise<void> {
     await this.pollForAvailability(() => {
       this.pack(registry, options);
     });

--- a/src/lib/npmCommand.ts
+++ b/src/lib/npmCommand.ts
@@ -13,6 +13,8 @@ import npmRunPath from 'npm-run-path';
 import * as shelljs from 'shelljs';
 
 import { SfdxError, fs } from '@salesforce/core';
+import { UX } from '@salesforce/command';
+import { sleep } from '@salesforce/kit';
 
 export type NpmMeta = {
   tarballUrl?: string;
@@ -184,5 +186,43 @@ export class NpmModule {
       throw new SfdxError(`Failed to fetch tarball from the registry: \n${sfdxErr.message}`, 'NpmError');
     }
     return;
+  }
+
+  public async fetchTarbarll(registry: string, options?: shelljs.ExecOptions): Promise<void> {
+    await this.pollForAvailability(() => {
+      this.pack(registry, options);
+    });
+    this.pack(registry, options);
+  }
+
+  public async pollForAvailability(checkFn: () => void): Promise<void> {
+    const ux = await UX.create();
+    const isNonTTY = process.env.CI !== undefined || process.env.CIRCLECI !== undefined;
+    let found = false;
+    let attempts = 0;
+    const maxAttempts = 300;
+
+    const start = isNonTTY ? (msg: string): UX => ux.log(msg) : (msg: string): void => ux.startSpinner(msg);
+    const update = isNonTTY ? (msg: string): UX => ux.log(msg) : (msg: string): void => ux.setSpinnerStatus(msg);
+    const stop = isNonTTY ? (msg: string): UX => ux.log(msg) : (msg: string): void => ux.stopSpinner(msg);
+
+    start('Polling for new version(s) to become available on npm');
+    while (!found && attempts < maxAttempts) {
+      attempts += 1;
+      update(`attempt: ${attempts} of ${maxAttempts}`);
+
+      try {
+        checkFn();
+        found = true;
+      } catch (error) {
+        if (attempts === maxAttempts) {
+          throw error;
+        }
+        found = false;
+      }
+
+      await sleep(1000);
+    }
+    stop(attempts >= maxAttempts ? 'failed' : 'done');
   }
 }

--- a/test/lib/installationVerification.test.ts
+++ b/test/lib/installationVerification.test.ts
@@ -21,7 +21,7 @@ import {
   VerificationConfig,
   Verifier,
 } from '../../src/lib/installationVerification';
-import { NpmMeta, NpmShowResults } from '../../src/lib/npmCommand';
+import { NpmMeta, NpmModule, NpmShowResults } from '../../src/lib/npmCommand';
 import { NpmName } from '../../src/lib/NpmName';
 import { CERTIFICATE, TEST_DATA, TEST_DATA_SIGNATURE } from '../testCert';
 
@@ -128,6 +128,7 @@ describe('InstallationVerification Tests', () => {
   let sandbox: sinon.SinonSandbox;
   let shelljsExecStub: Sinon.SinonStub;
   let shelljsFindStub: Sinon.SinonStub;
+  let pollForAvailabilityStub: Sinon.SinonStub;
 
   beforeEach(() => {
     sandbox = Sinon.createSandbox();
@@ -142,6 +143,7 @@ describe('InstallationVerification Tests', () => {
     realpathSyncStub = stubMethod(sandbox, fs, 'realpathSync').returns('node.exe');
     shelljsFindStub = stubMethod(sandbox, shelljs, 'find').returns(['node.exe']);
     plugin = NpmName.parse('foo');
+    pollForAvailabilityStub = stubMethod(sandbox, NpmModule.prototype, 'pollForAvailability').resolves();
   });
 
   afterEach(() => {
@@ -151,6 +153,7 @@ describe('InstallationVerification Tests', () => {
     if (shelljsExecStub) {
       shelljsExecStub.restore();
     }
+    pollForAvailabilityStub.restore();
   });
 
   after(() => {

--- a/test/lib/npmCommand.test.ts
+++ b/test/lib/npmCommand.test.ts
@@ -317,7 +317,7 @@ describe('should run npm commands with execution errors', () => {
       new NpmModule(MODULE_NAME, MODULE_VERSION, __dirname).pack(DEFAULT_REGISTRY, { cwd: CACHE_PATH });
       fail('Error');
     } catch (error) {
-      expect(error.code).to.equal('ShellExecError');
+      expect(error.code).to.equal('NpmError');
     }
   });
 });
@@ -363,15 +363,6 @@ describe('should run npm commands with parse errors', () => {
     try {
       const npmMetadata = new NpmModule(MODULE_NAME, MODULE_VERSION, __dirname).show(DEFAULT_REGISTRY);
       expect(npmMetadata).to.be.undefined;
-      fail('Error');
-    } catch (error) {
-      expect(error.code).to.equal('ShellParseError');
-    }
-  });
-
-  it('Runs the pack command', () => {
-    try {
-      new NpmModule(MODULE_NAME, MODULE_VERSION, __dirname).pack(DEFAULT_REGISTRY, { cwd: CACHE_PATH });
       fail('Error');
     } catch (error) {
       expect(error.code).to.equal('ShellParseError');


### PR DESCRIPTION
### What does this PR do?
Adds polling logic to `NpmModule`, add new method `fetchTarball` that polls `npm pack` until the tarball is available.
 
**Note**:
[plugin-rel-mgmt already polls `npm view` in the release process ](https://github.com/salesforcecli/plugin-release-management/blob/251fdf34eef5e1d758dd92f4e32e780b5989a03c/src/repository.ts#L154),`npm pack` is the one failing right after `npm view` successfully retrieves the metadata.

Circle logs (signature verification step failed):
[plugin-source](https://app.circleci.com/pipelines/github/salesforcecli/plugin-source/1374/workflows/045c3207-5c40-436c-b25d-5204a8940cdb/jobs/4406/parallel-runs/0/steps/0-118)
[toolbelt](https://app.circleci.com/pipelines/github/salesforcecli/toolbelt/729/workflows/fa389933-53ea-46a1-a98d-1e1a1c9a8344/jobs/3953/parallel-runs/0/steps/0-118)


**Depends on** https://github.com/salesforcecli/plugin-trust/pull/182

### What issues does this PR fix or reference?
@W-10065192@