### PR TITLE
fix: add `request` to pkg dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@salesforce/core": "^3.10.1",
     "npm": "^8.12.1",
     "npm-run-path": "^4.0.1",
+    "request": "^2.88.2",
     "shelljs": "^0.8.4",
     "tslib": "^2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7063,7 +7063,7 @@ replace-ext@^1.0.0:
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.1.tgz#2d6d996d04a15855d967443631dd5f77825b016a"
   integrity sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw==
 
-request@^2.72.0:
+request@^2.72.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==


### PR DESCRIPTION
### What does this PR do?
Adds `request` dep to the pjson.
The dep is already being used: https://github.com/salesforcecli/plugin-trust/blob/1affd57bd25563be4278c16b9249c8d765475ca6/src/shared/installationVerification.ts#L21
when bundling plugin-trust in an npm project that doesn't have this dependency it fails to build.

### What issues does this PR fix or reference?
@W-0@
