### PR TITLE
fix: jit with json

### DIFF
--- a/.github/workflows/onPushToMain.yml
+++ b/.github/workflows/onPushToMain.yml
@@ -3,12 +3,18 @@ name: version, tag and github release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - prerelease/*
+    tags-ignore:
+      - '*'
 
 jobs:
   release:
     uses: salesforcecli/github-workflows/.github/workflows/githubRelease.yml@main
     secrets: inherit
+    with:
+      prerelease: ${{ github.ref_name != 'main' }}
 
   # most repos won't use this
   # depends on previous job to avoid git collisions, not for any functionality reason

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -2,20 +2,33 @@ name: publish
 
 on:
   release:
-    types: [released]
-  # support manual release in case something goes wrong and needs to be repeated or tested
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
         description: tag that needs to publish
         type: string
         required: true
+
 jobs:
+  # parses the package.json version and detects prerelease tag (ex: beta from 4.4.4-beta.0)
+  getDistTag:
+    outputs:
+      tag: ${{ steps.distTag.outputs.tag }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag  }}
+      - uses: salesforcecli/github-workflows/.github/actions/getPreReleaseTag@main
+        id: distTag
+
   npm:
     uses: salesforcecli/github-workflows/.github/workflows/npmPublish.yml@main
+    needs: [getDistTag]
     with:
+      tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
+      githubTag: ${{ github.event.release.tag_name || inputs.tag }}
       ctc: true
       sign: true
-      tag: latest
-      githubTag: ${{ github.event.release.tag_name || inputs.tag }}
     secrets: inherit

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-trust",
   "description": "validate a digital signature for a npm package",
-  "version": "2.4.12",
+  "version": "2.5.0-qa.0",
   "author": "Salesforce",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-trust",
   "description": "validate a digital signature for a npm package",
-  "version": "2.5.0-qa.0",
+  "version": "2.5.0-qa.1",
   "author": "Salesforce",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@salesforce/plugin-trust",
   "description": "validate a digital signature for a npm package",
-  "version": "2.5.0-qa.1",
+  "version": "2.4.13",
   "author": "Salesforce",
   "main": "lib/index.js",
   "bin": {

--- a/src/hooks/verifyInstallSignature.ts
+++ b/src/hooks/verifyInstallSignature.ts
@@ -34,6 +34,15 @@ export const hook: Hook.PluginsPreinstall = async function (options) {
     const logger = await Logger.child('verifyInstallSignature');
     const plugin = options.plugin;
 
+    // skip if the plugin version being installed is listed in the CLI's JIT config
+    if (
+      plugin.tag &&
+      plugin.name in options.config.pjson.oclif.jitPlugins &&
+      options.config.pjson.oclif.jitPlugins?.[plugin.name] === plugin.tag
+    ) {
+      logger.debug(`Skipping verification for ${options.plugin.name} because it is listed in the CLI's JIT config.`);
+      return;
+    }
     logger.debug('parsing npm name');
     const npmName = NpmName.parse(plugin.name);
     logger.debug(`npmName components: ${JSON.stringify(npmName, null, 4)}`);


### PR DESCRIPTION
> this is on prerelease.  be sure to remove the `qa` tag before merging.

### What does this PR do?
background https://salesforce-internal.slack.com/archives/G02K6C90RBJ/p1682563856812799

skips the signature check if the plugin being installed is in the CLI's JIT list
because the sig verification stuff writes to stdout
which breaks json output when `sf some:jit --json` prints messages from the verification. 

QA: 
just-nuts from [here](https://github.com/salesforcecli/cli/actions/runs/4820315494) should work better with (ex) [plugin-signups](https://github.com/salesforcecli/cli/actions/runs/4820315494/jobs/8586009528) that were previously failing like [this](https://github.com/salesforcecli/cli/actions/runs/4813536200/jobs/8574084844)
you can run something jit with json (ex: `sf org list shape --json > result.json`) and verify the json using `sf@qa` OR taking any old `sf` and running `sf plugins install @salesforce/plugin-trust@qa`


### What issues does this PR fix or reference?
@W-13112067@