### PR TITLE
refactor: don't import all of telemetry just for a string

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@oclif/core": "^2.11.8",
     "@salesforce/core": "^5.2.0",
     "@salesforce/sf-plugins-core": "^3.1.14",
-    "@salesforce/telemetry": "^4.1.0",
     "got": "^11",
     "npm": "^8.19.4",
     "npm-run-path": "^4.0.1",

--- a/src/hooks/jitPluginInstall.ts
+++ b/src/hooks/jitPluginInstall.ts
@@ -8,7 +8,6 @@ import * as os from 'os';
 import { Hook } from '@oclif/core';
 import { SfError } from '@salesforce/core';
 import { TelemetryGlobal } from '@salesforce/plugin-telemetry/lib/telemetryGlobal';
-import { AppInsights } from '@salesforce/telemetry/lib/appInsights';
 
 declare const global: TelemetryGlobal;
 
@@ -37,9 +36,7 @@ const hook: Hook<'jit_plugin_not_installed'> = async function (opts) {
       type: 'EVENT',
       message: error instanceof Error ? error.message : 'malformed error',
       stackTrace:
-        error instanceof Error
-          ? error?.stack?.replace(new RegExp(os.homedir(), 'g'), AppInsights.GDPR_HIDDEN)
-          : undefined,
+        error instanceof Error ? error?.stack?.replace(new RegExp(os.homedir(), 'g'), '<GDPR_HIDDEN>') : undefined,
       version: opts.pluginVersion,
       plugin: opts.command.pluginName,
       command: opts.command.id,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,17 +1390,6 @@
     applicationinsights "^2.6.0"
     axios "^1.4.0"
 
-"@salesforce/telemetry@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@salesforce/telemetry/-/telemetry-4.1.0.tgz#7ba69cb5c00fe108fa179e6a3ac8a0534c649ab8"
-  integrity sha512-Z5zg1l0yLoRRDJF3aR3bdicDNe2KoSizg4BCaTQe7WAhJErfRpv+7QcTs4LZkD2jxtJnl7RiBR9DYx2fTLcQaQ==
-  dependencies:
-    "@salesforce/core" "^5.2.0"
-    "@salesforce/ts-types" "^2.0.6"
-    applicationinsights "^2.7.0"
-    got "^11"
-    proxy-agent "^6.3.0"
-
 "@salesforce/ts-sinon@^1.4.6":
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/@salesforce/ts-sinon/-/ts-sinon-1.4.8.tgz#9c3f2f5616f42d0b4fd1562946d1ffc6f4528916"
@@ -2048,7 +2037,7 @@ append-transform@^2.0.0:
   dependencies:
     default-require-extensions "^3.0.0"
 
-applicationinsights@^2.6.0, applicationinsights@^2.7.0:
+applicationinsights@^2.6.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-2.7.0.tgz#b397b750e788c010d564c3ef7f5ce6e62227b425"
   integrity sha512-/vV5X6M4TlRA5NxNZAdCE0gukzfK24mb3z18D5Kl/CyIfSVIkafsIji3mK+Zi5q+7dn6H1CkFazlcnLf40anHw==


### PR DESCRIPTION
### What does this PR do?
hardcode GDPR replacement string to avoid a large import of a non-exported class

### What issues does this PR fix or reference?
https://github.com/salesforcecli/cli/actions/runs/5868899251/job/15913774669