### PR TITLE
fix: support 403 allowlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We always recommend using the latest version of these commands bundled with the 
 
 ### Allowlisting
 
-If a plugin needs to be installed in a unattended fashion as is the case with automation. The plugin acceptance prompt can be avoided by placing the plugin name in \$HOME/.config/sfdx/unsignedPluginAllowList.json
+If a plugin needs to be installed in a unattended fashion as is the case with automation. The plugin acceptance prompt can be avoided by placing the plugin name in \$HOME/.config/sf/unsignedPluginAllowList.json
 
 ```json
 [

--- a/src/shared/installationVerification.ts
+++ b/src/shared/installationVerification.ts
@@ -467,7 +467,7 @@ export async function doInstallationCodeSigningVerification(
     verificationConfig.log(`Successfully validated digital signature for ${plugin.plugin}.`);
   } catch (err) {
     if (err instanceof Error) {
-      if (err.name === 'NotSigned') {
+      if (err.name === 'NotSigned' || err.message === 'Response code 403 (Forbidden)') {
         if (!verificationConfig.verifier) {
           throw new Error('VerificationConfig.verifier is not set.');
         }


### PR DESCRIPTION
### What does this PR do?
If the signature or cert cannot be found, you can now continue to install the plugin by using the allowList

QA
- Pull and link `plugin-trust`
- Create a file at `$HOME/.config/sf/unsignedPluginAllowList.json`
- Add `["@salesforce/lwc-dev-server"]`
- Run `sf plugins install @salesforce/lwc-dev-server`
- Verify message and install
  - `The plugin [@salesforce/lwc-dev-server] is not digitally signed but it is allow-listed.`


### What issues does this PR fix or reference?
[@W-14129526@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14129526)