### PR TITLE
Look for SF_NPM_REGISTRY

### DIFF
--- a/src/commands/plugins/trust/verify.ts
+++ b/src/commands/plugins/trust/verify.ts
@@ -66,6 +66,7 @@ export class Verify extends SfCommand<VerifyResponse> {
     vConfig.verifier = Verify.getVerifier(npmName, configContext);
 
     if (flags.registry) {
+      process.env.SF_NPM_REGISTRY = flags.registry;
       process.env.SFDX_NPM_REGISTRY = flags.registry;
     }
 

--- a/src/shared/installationVerification.ts
+++ b/src/shared/installationVerification.ts
@@ -151,7 +151,8 @@ const errorHandlerForVerify = (err: Error): Error => {
   return err;
 };
 
-export const getNpmRegistry = (): URL => new URL(process.env.SFDX_NPM_REGISTRY ?? DEFAULT_REGISTRY);
+export const getNpmRegistry = (): URL =>
+  new URL(process.env.SF_NPM_REGISTRY ?? process.env.SFDX_NPM_REGISTRY ?? DEFAULT_REGISTRY);
 
 /**
  * class for verifying a digital signature pack of an npm

--- a/test/shared/installationVerification.test.ts
+++ b/test/shared/installationVerification.test.ts
@@ -88,13 +88,24 @@ const getShelljsExecStub = (
   });
 
 describe('getNpmRegistry', () => {
-  const currentRegistry = process.env.SFDX_NPM_REGISTRY;
+  const currentSFRegistry = process.env.SF_NPM_REGISTRY;
+  const currentSFDXRegistry = process.env.SFDX_NPM_REGISTRY;
   after(() => {
-    if (currentRegistry) {
-      process.env.SFDX_NPM_REGISTRY = currentRegistry;
+    if (currentSFRegistry) {
+      process.env.SF_NPM_REGISTRY = currentSFRegistry;
+    }
+    if (currentSFDXRegistry) {
+      process.env.SFDX_NPM_REGISTRY = currentSFDXRegistry;
     }
   });
-  it('set registry', () => {
+  it('set SF registry', () => {
+    const TEST_REG = 'https://registry.example.com/';
+    process.env.SF_NPM_REGISTRY = TEST_REG;
+    const reg = getNpmRegistry();
+    expect(reg.href).to.be.equal(TEST_REG);
+  });
+  it('set SFDX registry', () => {
+    delete process.env.SF_NPM_REGISTRY;
     const TEST_REG = 'https://registry.example.com/';
     process.env.SFDX_NPM_REGISTRY = TEST_REG;
     const reg = getNpmRegistry();


### PR DESCRIPTION
### What does this PR do?
We suggest using `SF_NPM_REGISTRY`
> Deprecated environment variable: SFDX_NPM_REGISTRY. Please use SF_NPM_REGISTRY instead.

However, `plugin-trust` did not look for that env var when verifying signatures. 

### QA
You can link this to your locally installed `sf`. After linking and setting a bogus registry with `SF_NPM_REGISTRY`, you will see a warning
```
{
  errno: -3008,
  code: 'ENOTFOUND',
  syscall: 'getaddrinfo',
  hostname: 'registry.npmjs-foo.org'
},
```

### What issues does this PR fix or reference?
https://github.com/forcedotcom/cli/issues/2517
[@W-14277809@](https://gus.my.salesforce.com/apex/ADM_WorkLocator?bugorworknumber=W-14277809)