### PR TITLE
fix: pass json flag to plugins install

### DIFF
--- a/src/hooks/jitPluginInstall.ts
+++ b/src/hooks/jitPluginInstall.ts
@@ -21,7 +21,12 @@ const hook: Hook<'jit_plugin_not_installed'> = async function (opts) {
       command: opts.command.id,
     });
 
-    await opts.config.runCommand('plugins:install', [`${opts.command.pluginName}@${opts.pluginVersion}`]);
+    const jitInstallArgv = [`${opts.command.pluginName}@${opts.pluginVersion}`];
+    if (opts.argv.includes('--json')) {
+      // pass along --json arg to plugins:install
+      jitInstallArgv.push('--json');
+    }
+    await opts.config.runCommand('plugins:install', jitInstallArgv);
 
     global.cliTelemetry?.record({
       eventName: 'JIT_INSTALL_SUCCESS',


### PR DESCRIPTION
### What does this PR do?
If a JIT plugin command is run with `--json` and that plugin is not yet installed (such as in a CI system) the output from the JIT install (which is not JSON) would mix with the JSON to cause problems.  This fix passes along the `--json` flag to the call to plugins:install so the output is still valid JSON.

E.g., `sf package version create ... --json` would cause output like:
```
Successfully installed @salesforce/plugin-packaging v1.27.0
  {
    "status": 0,
    "result": {
      "Id": "<PACKAGE_ID>",
      ...
    },
    "warnings": []
  }
```
With the fix, the output contains only JSON.

### What issues does this PR fix or reference?
@W-14457843@
https://github.com/forcedotcom/cli/issues/2562