### PR TITLE
feat: allow any 403 response to continue verification

### DIFF
--- a/src/shared/installationVerification.ts
+++ b/src/shared/installationVerification.ts
@@ -469,7 +469,7 @@ export async function doInstallationCodeSigningVerification(
     verificationConfig.log(`Successfully validated digital signature for ${plugin.plugin}.`);
   } catch (err) {
     if (err instanceof Error) {
-      if (err.name === 'NotSigned' || err.message && err.message.includes('Response code 403')) {
+      if (err.name === 'NotSigned' || err.message?.includes('Response code 403')) {
         if (!verificationConfig.verifier) {
           throw new Error('VerificationConfig.verifier is not set.');
         }

--- a/src/shared/installationVerification.ts
+++ b/src/shared/installationVerification.ts
@@ -469,7 +469,7 @@ export async function doInstallationCodeSigningVerification(
     verificationConfig.log(`Successfully validated digital signature for ${plugin.plugin}.`);
   } catch (err) {
     if (err instanceof Error) {
-      if (err.name === 'NotSigned' || err.message === 'Response code 403 (Forbidden)') {
+      if (err.name === 'NotSigned' || err.message && err.message.includes('Response code 403')) {
         if (!verificationConfig.verifier) {
           throw new Error('VerificationConfig.verifier is not set.');
         }

--- a/test/shared/installationVerification.test.ts
+++ b/test/shared/installationVerification.test.ts
@@ -685,5 +685,55 @@ describe('InstallationVerification Tests', () => {
         throw err;
       }
     });
+
+    it('continues installation when error message is response code 403 (forbidden)', async () => {
+      const vConfig = new VerificationConfig();
+      vConfig.verifier = {
+        async verify() {
+          const err = new Error();
+          err.message = 'Response code 403 (Forbidden)';
+          throw err;
+        },
+        async isAllowListed() {
+          return false;
+        },
+      } as Verifier;
+
+      stubMethod(sandbox, Prompter.prototype, 'confirm').resolves(true);
+
+      try {
+        await doInstallationCodeSigningVerification({}, BLANK_PLUGIN, vConfig);
+      } catch (e) {
+        assert(e instanceof Error);
+        const err = new Error("this test shouldn't fail.");
+        err.stack = e.stack;
+        throw err;
+      }
+    });
+
+    it('continues installation when error message contains response code 403', async () => {
+      const vConfig = new VerificationConfig();
+      vConfig.verifier = {
+        async verify() {
+          const err = new Error();
+          err.message = 'Response code 403 (OtherReason)';
+          throw err;
+        },
+        async isAllowListed() {
+          return false;
+        },
+      } as Verifier;
+
+      stubMethod(sandbox, Prompter.prototype, 'confirm').resolves(true);
+
+      try {
+        await doInstallationCodeSigningVerification({}, BLANK_PLUGIN, vConfig);
+      } catch (e) {
+        assert(e instanceof Error);
+        const err = new Error("this test shouldn't fail.");
+        err.stack = e.stack;
+        throw err;
+      }
+    });
   });
 });


### PR DESCRIPTION
### What does this PR do?
Allows any 403 response to proceed to plugin verification bypass. Previously restricted to errors with a more specific 403 (Forbidden) message.

### What issues does this PR fix or reference?
forcedotcom/cli/issues/2584 
@W-14581522@
