### PR TITLE
feat: check allowList before making callouts

### DIFF
--- a/messages/verify.md
+++ b/messages/verify.md
@@ -20,6 +20,18 @@ Specify the npm name. This can include a tag/version.
 
 The registry name. The behavior is the same as npm.
 
+# NotSigned
+
+The plugin is not digitally signed.
+
+# SignatureCheckSuccess
+
+Successfully validated digital signature for %s.
+
+# SkipSignatureCheck
+
+Skipping digital signature verification because [%s] is allow-listed.
+
 # FailedDigitalSignatureVerification
 
 A digital signature is specified for this plugin but it didn't verify against the certificate.

--- a/messages/verify.md
+++ b/messages/verify.md
@@ -22,7 +22,7 @@ The registry name. The behavior is the same as npm.
 
 # NotSigned
 
-The plugin is not digitally signed.
+The plugin isn't digitally signed.
 
 # SignatureCheckSuccess
 

--- a/src/commands/plugins/trust/verify.ts
+++ b/src/commands/plugins/trust/verify.ts
@@ -72,7 +72,7 @@ export class Verify extends SfCommand<VerifyResponse> {
     vConfig.verifier = Verify.getVerifier(npmName, configContext);
 
     if (await vConfig.verifier.isAllowListed()) {
-      const message = `Skipping digital signature verification because [${npmName.name}] is allow-listed.`;
+      const message = messages.getMessage('SkipSignatureCheck', [npmName.name]);
       this.log(message);
       return {
         message,
@@ -92,7 +92,7 @@ export class Verify extends SfCommand<VerifyResponse> {
         const e = messages.createError('FailedDigitalSignatureVerification');
         throw setErrorName(e, 'FailedDigitalSignatureVerification');
       }
-      const message = `Successfully validated digital signature for ${npmName.name}.`;
+      const message = messages.getMessage('SignatureCheckSuccess', [npmName.name]);
       this.logSuccess(message);
 
       return { message, verified: true };
@@ -103,7 +103,7 @@ export class Verify extends SfCommand<VerifyResponse> {
       logger.debug(`err reported: ${JSON.stringify(error, null, 4)}`);
 
       if (error.name === 'NotSigned') {
-        const message = 'The plugin is not digitally signed.';
+        const message = messages.getMessage('NotSigned');
         this.log(message);
         return {
           verified: false,

--- a/src/commands/plugins/trust/verify.ts
+++ b/src/commands/plugins/trust/verify.ts
@@ -71,6 +71,14 @@ export class Verify extends SfCommand<VerifyResponse> {
 
     vConfig.verifier = Verify.getVerifier(npmName, configContext);
 
+    if (await vConfig.verifier.isAllowListed()) {
+      const message = `Skipping digital signature verification because [${npmName.name}] is allow-listed.`;
+      this.log(message);
+      return {
+        message,
+        verified: false,
+      };
+    }
     if (flags.registry) {
       process.env.SF_NPM_REGISTRY = flags.registry;
       process.env.SFDX_NPM_REGISTRY = flags.registry;
@@ -85,33 +93,22 @@ export class Verify extends SfCommand<VerifyResponse> {
         throw setErrorName(e, 'FailedDigitalSignatureVerification');
       }
       const message = `Successfully validated digital signature for ${npmName.name}.`;
+      this.logSuccess(message);
 
-      if (!flags.json) {
-        vConfig.log(message);
-      }
       return { message, verified: true };
     } catch (error) {
       if (!(error instanceof Error)) {
         throw error;
       }
       logger.debug(`err reported: ${JSON.stringify(error, null, 4)}`);
-      const response: VerifyResponse = {
-        verified: false,
-        message: error.message,
-      };
 
       if (error.name === 'NotSigned') {
-        let message: string = error.message;
-        if (await vConfig.verifier.isAllowListed()) {
-          message = `The plugin [${npmName.name}] is not digitally signed but it is allow-listed.`;
-          vConfig.log(message);
-          response.message = message;
-        } else {
-          message = 'The plugin is not digitally signed.';
-          vConfig.log(message);
-          response.message = message;
-        }
-        return response;
+        const message = 'The plugin is not digitally signed.';
+        this.log(message);
+        return {
+          verified: false,
+          message,
+        };
       }
       throw SfError.wrap(error);
     }

--- a/src/shared/installationVerification.ts
+++ b/src/shared/installationVerification.ts
@@ -446,8 +446,10 @@ export async function doInstallationCodeSigningVerification(
   plugin: { plugin: string; tag: string },
   verificationConfig: VerificationConfig
 ): Promise<void> {
+  const messages = Messages.loadMessages('@salesforce/plugin-trust', 'verify');
+
   if (await verificationConfig.verifier?.isAllowListed()) {
-    verificationConfig.log(`The plugin [${plugin.plugin}] is allow-listed, skipping digital signature verification.`);
+    verificationConfig.log(messages.getMessage('SkipSignatureCheck', [plugin.plugin]));
     return;
   }
   try {
@@ -456,13 +458,10 @@ export async function doInstallationCodeSigningVerification(
     }
     const meta = await verificationConfig.verifier.verify();
     if (!meta.verified) {
-      const err = new SfError(
-        "A digital signature is specified for this plugin but it didn't verify against the certificate.",
-        'FailedDigitalSignatureVerification'
-      );
+      const err = messages.createError('FailedDigitalSignatureVerification');
       throw setErrorName(err, 'FailedDigitalSignatureVerification');
     }
-    verificationConfig.log(`Successfully validated digital signature for ${plugin.plugin}.`);
+    verificationConfig.log(messages.getMessage('SignatureCheckSuccess', [plugin.plugin]));
   } catch (err) {
     if (err instanceof Error) {
       if (err.name === 'NotSigned' || err.message?.includes('Response code 403')) {

--- a/test/nuts/plugin-install.nut.ts
+++ b/test/nuts/plugin-install.nut.ts
@@ -61,7 +61,7 @@ describe('plugins:install commands', () => {
       ensureExitCode: 0,
       cli: 'sf',
     });
-    expect(result.shellOutput.stdout).to.contain(`Successfully validated digital signature for ${SIGNED_MODULE_NAME}`);
+    expect(result.shellOutput.stdout).to.contain(messages.getMessage('SignatureCheckSuccess', [SIGNED_MODULE_NAME]));
   });
 
   it('plugins:install prompts on unsigned plugin (denies)', async () => {
@@ -102,8 +102,6 @@ describe('plugins:install commands', () => {
       ensureExitCode: 0,
       cli: 'sf',
     });
-    expect(result.shellOutput.stdout).to.contain(
-      `The plugin [${UNSIGNED_MODULE_NAME2}] is not digitally signed but it is allow-listed.`
-    );
+    expect(result.shellOutput.stdout).to.contain(messages.getMessage('SkipSignatureCheck', [UNSIGNED_MODULE_NAME2]));
   });
 });

--- a/test/shared/installationVerification.test.ts
+++ b/test/shared/installationVerification.test.ts
@@ -582,6 +582,9 @@ describe('InstallationVerification Tests', () => {
       let message = '';
       const vConfig = new VerificationConfig();
       vConfig.verifier = {
+        async isAllowListed() {
+          return false;
+        },
         async verify() {
           return {
             verified: true,
@@ -601,6 +604,9 @@ describe('InstallationVerification Tests', () => {
     it('FailedDigitalSignatureVerification', async () => {
       const vConfig = new VerificationConfig();
       vConfig.verifier = {
+        async isAllowListed() {
+          return false;
+        },
         async verify() {
           return {
             verified: false,


### PR DESCRIPTION
### What does this PR do?
check the allowList first before making callouts via npm.  Not only should this save time for allowListed plugins, but it also means the allowList is a way of bypassing the check entirely, which is a quick-fix for the people with all the weird registry/firewall/proxy issues.

### What issues does this PR fix or reference?
it's a broader fix than the one already merged for 
forcedotcom/cli/issues/2584
@W-14581522@

