### PR TITLE
fix: allow semver ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "npm": "10.2.3",
     "npm-run-path": "^4.0.1",
     "proxy-agent": "^6.3.1",
+    "semver": "^7.5.4",
     "shelljs": "^0.8.4"
   },
   "devDependencies": {

--- a/src/shared/installationVerification.ts
+++ b/src/shared/installationVerification.ts
@@ -17,6 +17,7 @@ import got from 'got';
 import { ProxyAgent } from 'proxy-agent';
 import { ux } from '@oclif/core';
 import { prompts } from '@salesforce/sf-plugins-core';
+import { maxSatisfying } from 'semver';
 import { NpmModule, NpmMeta } from './npmCommand.js';
 import { NpmName } from './NpmName.js';
 import { setErrorName } from './errors.js';
@@ -348,7 +349,9 @@ export class InstallationVerification implements Verifier {
     }
 
     // Assume the tag is version tag.
-    let versionNumber = npmMetadata.versions.find((version) => version === this.pluginNpmName?.tag);
+    let versionNumber =
+      maxSatisfying(npmMetadata.versions, this.pluginNpmName.tag) ??
+      npmMetadata.versions.find((version) => version === this.pluginNpmName?.tag);
 
     logger.debug(`retrieveNpmMeta | versionObject: ${JSON.stringify(versionNumber)}`);
 
@@ -363,7 +366,9 @@ export class InstallationVerification implements Verifier {
 
         // if we got a dist tag hit look up the version object
         if (tagVersionStr && tagVersionStr.length > 0 && tagVersionStr.includes('.')) {
-          versionNumber = npmMetadata.versions.find((version) => version === tagVersionStr);
+          versionNumber =
+            maxSatisfying(npmMetadata.versions, tagVersionStr) ??
+            npmMetadata.versions.find((version) => version === tagVersionStr);
           logger.debug(`retrieveNpmMeta | versionObject: ${versionNumber}`);
         } else {
           const err = new SfError(

--- a/src/shared/npmCommand.ts
+++ b/src/shared/npmCommand.ts
@@ -173,7 +173,13 @@ export class NpmModule {
     }
 
     try {
-      return JSON.parse(showCmd.stdout) as NpmShowResults;
+      // `npm show` returns an array of results when the version is a range
+      const raw = JSON.parse(showCmd.stdout) as NpmShowResults | NpmShowResults[];
+      if (Array.isArray(raw)) {
+        // Return the last result in the array since that will be the highest version
+        return raw.at(-1) ?? raw[0];
+      }
+      return raw;
     } catch (error) {
       if (error instanceof Error) {
         throw setErrorName(new SfError(error.message, 'ShellParseError'), 'ShellParseError');

--- a/src/shared/npmCommand.ts
+++ b/src/shared/npmCommand.ts
@@ -177,7 +177,8 @@ export class NpmModule {
       const raw = JSON.parse(showCmd.stdout) as NpmShowResults | NpmShowResults[];
       if (Array.isArray(raw)) {
         // Return the last result in the array since that will be the highest version
-        return raw.at(-1) ?? raw[0];
+        // NOTE: .at() possibly returns undefined so instead directly index the array for the last element
+        return raw[raw.length - 1];
       }
       return raw;
     } catch (error) {


### PR DESCRIPTION
### What does this PR do?

Support semver ranges when verifying signature (e.g. `sf plugins install auth@^3.3.3`)

### What issues does this PR fix or reference?
@W-11771849@
