### PR TITLE
feat: support allowed github urls

### DIFF
--- a/messages/verify.md
+++ b/messages/verify.md
@@ -38,7 +38,7 @@ A digital signature is specified for this plugin but it didn't verify against th
 
 # InstallConfirmation
 
-%s isn't signed by Salesforce. Only install the plugin if you trust its creator. Do you want to continue the installation?,
+%s isn't signed by Salesforce. Only install the plugin if you trust its creator. Do you want to continue the installation?
 
 # SuggestAllowList
 

--- a/messages/verify.md
+++ b/messages/verify.md
@@ -38,7 +38,7 @@ A digital signature is specified for this plugin but it didn't verify against th
 
 # InstallConfirmation
 
-This plugin isn't signed by Salesforce. Only install the plugin if you trust its creator. Do you want to continue the installation?,
+%s isn't signed by Salesforce. Only install the plugin if you trust its creator. Do you want to continue the installation?,
 
 # SuggestAllowList
 

--- a/src/hooks/verifyInstallSignature.ts
+++ b/src/hooks/verifyInstallSignature.ts
@@ -6,7 +6,7 @@
  */
 
 import { Hook } from '@oclif/core';
-import { Logger } from '@salesforce/core';
+import { Logger, Messages } from '@salesforce/core';
 import { ux } from '@oclif/core';
 import {
   ConfigContext,
@@ -14,6 +14,7 @@ import {
   doPrompt,
   InstallationVerification,
   VerificationConfig,
+  isAllowListed,
 } from '../shared/installationVerification.js';
 
 import { NpmName } from '../shared/NpmName.js';
@@ -43,7 +44,7 @@ export const hook: Hook.PluginsPreinstall = async function (options) {
       npmName.tag = npmName.tag.slice(1);
     }
 
-    const configContext: ConfigContext = {
+    const configContext = {
       cacheDir: options.config.cacheDir,
       configDir: options.config.configDir,
       dataDir: options.config.dataDir,
@@ -64,8 +65,20 @@ export const hook: Hook.PluginsPreinstall = async function (options) {
       logger.debug(error.message);
       this.error(error);
     }
+  } else if (options.plugin.url) {
+    const isAllowed = await isAllowListed({
+      logger: await Logger.child('verifyInstallSignature'),
+      name: options.plugin.url,
+      configPath: options.config.configDir,
+    });
+    if (isAllowed) {
+      const messages = Messages.loadMessages('@salesforce/plugin-trust', 'verify');
+      ux.log(messages.getMessage('SkipSignatureCheck', [options.plugin.url]));
+    } else {
+      await doPrompt(options.plugin.url);
+    }
   } else {
-    await doPrompt(options.plugin.url);
+    await doPrompt();
   }
 };
 

--- a/src/hooks/verifyInstallSignature.ts
+++ b/src/hooks/verifyInstallSignature.ts
@@ -65,7 +65,7 @@ export const hook: Hook.PluginsPreinstall = async function (options) {
       this.error(error);
     }
   } else {
-    await doPrompt();
+    await doPrompt(options.plugin.url);
   }
 };
 

--- a/src/shared/installationVerification.ts
+++ b/src/shared/installationVerification.ts
@@ -437,9 +437,14 @@ export class VerificationConfig {
   }
 }
 
-export async function doPrompt(): Promise<void> {
+export async function doPrompt(plugin?: string): Promise<void> {
   const messages = Messages.loadMessages('@salesforce/plugin-trust', 'verify');
-  if (!(await prompts.confirm({ message: messages.getMessage('InstallConfirmation'), ms: 30_000 }))) {
+  if (
+    !(await prompts.confirm({
+      message: messages.getMessage('InstallConfirmation', [plugin ?? 'This plugin']),
+      ms: 30_000,
+    }))
+  ) {
     throw new SfError('The user canceled the plugin installation.', 'InstallationCanceledError');
   }
   // they approved the plugin.  Let them know how to automate this.
@@ -473,7 +478,7 @@ export async function doInstallationCodeSigningVerification(
         if (!verificationConfig.verifier) {
           throw new Error('VerificationConfig.verifier is not set.');
         }
-        return await doPrompt();
+        return await doPrompt(plugin.plugin);
       } else if (err.name === 'PluginNotFound' || err.name === 'PluginAccessDenied') {
         throw setErrorName(new SfError(err.message ?? 'The user canceled the plugin installation.'), '');
       }

--- a/test/nuts/plugin-install.nut.ts
+++ b/test/nuts/plugin-install.nut.ts
@@ -73,7 +73,7 @@ describe('plugins:install commands', () => {
     );
 
     expect(replaceAllWhitespace(result.stdout)).to.contain(
-      replaceAllWhitespace(messages.getMessage('InstallConfirmation'))
+      replaceAllWhitespace(messages.getMessage('InstallConfirmation', [UNSIGNED_MODULE_NAME]))
     );
     expect(result.stdout).to.contain('Do you want to continue the installation?');
     expect(result.stderr).to.contain('The user canceled the plugin installation');
@@ -89,7 +89,7 @@ describe('plugins:install commands', () => {
       }
     );
     expect(replaceAllWhitespace(result.stdout)).to.contain(
-      replaceAllWhitespace(messages.getMessage('InstallConfirmation'))
+      replaceAllWhitespace(messages.getMessage('InstallConfirmation', [UNSIGNED_MODULE_NAME]))
     );
     expect(result.stdout).to.contain('Do you want to continue the installation?');
     expect(result.stdout).to.contain('Finished digital signature check');


### PR DESCRIPTION
### What does this PR do?

- Support allow-listed github urls (e.g. https://github.com/oclif/plugin-version)
  - only `https://github.com/<org>/<repo>` is supported. You cannot use `https://github.com/<org>/<repo>.git`, `https://github.com/<org>/<repo>#commit`, etc...
- Display plugin name in prompt instead of `This plugin`

### What issues does this PR fix or reference?
@W-15313997@