### PR TITLE
fix: add `node info` W-18451508

### DIFF
--- a/command-snapshot.json
+++ b/command-snapshot.json
@@ -1,6 +1,14 @@
 [
   {
     "alias": [],
+    "command": "node:info",
+    "flagAliases": [],
+    "flagChars": [],
+    "flags": ["flags-dir", "json"],
+    "plugin": "@salesforce/plugin-trust"
+  },
+  {
+    "alias": [],
     "command": "plugins:trust:verify",
     "flagAliases": [],
     "flagChars": ["n", "r"],

--- a/messages/node.info.md
+++ b/messages/node.info.md
@@ -1,0 +1,7 @@
+# summary
+
+Returns the path to node and npx files bundled by the Salesforce CLI.
+
+# description
+
+Command for internal use only.

--- a/src/commands/node/info.ts
+++ b/src/commands/node/info.ts
@@ -19,6 +19,7 @@ export type NodeInfoResult = {
 
 export default class NodeInfo extends SfCommand<NodeInfoResult> {
   public static readonly summary = messages.getMessage('summary');
+  public static readonly description = messages.getMessage('description');
   public static readonly hidden = true;
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/src/commands/node/info.ts
+++ b/src/commands/node/info.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import { SfCommand } from '@salesforce/sf-plugins-core';
+import { Messages } from '@salesforce/core';
+import { NpmCommand } from '../../shared/npmCommand.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+const messages = Messages.loadMessages('@salesforce/plugin-trust', 'node.info');
+
+export type NodeInfoResult = {
+  nodePath: string;
+  npxPath: string;
+};
+
+export default class NodeInfo extends SfCommand<NodeInfoResult> {
+  public static readonly summary = messages.getMessage('summary');
+  public static readonly hidden = true;
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  public async run(): Promise<NodeInfoResult> {
+    return {
+      nodePath: NpmCommand.findNode(this.config.root),
+      npxPath: NpmCommand.npxCli(),
+    };
+  }
+}

--- a/src/shared/npmCommand.ts
+++ b/src/shared/npmCommand.ts
@@ -56,7 +56,7 @@ type NpmPackage = {
   };
 };
 
-class NpmCommand {
+export class NpmCommand {
   public static runNpmCmd(cmd: string, options = {} as NpmCommandOptions): NpmCommandResult {
     const nodeExecutable = NpmCommand.findNode(options.cliRoot);
     const npmCli = NpmCommand.npmCli();
@@ -74,12 +74,7 @@ class NpmCommand {
     return npmCmdResult;
   }
 
-  /**
-   * Returns the path to the npm-cli.js file in this package's node_modules
-   *
-   * @private
-   */
-  private static npmCli(): string {
+  public static npxCli(): string {
     const require = createRequire(import.meta.url);
     const pkgPath = require.resolve('npm/package.json');
 
@@ -87,7 +82,7 @@ class NpmCommand {
     const pkgJson = parseJson(fileData, pkgPath) as NpmPackage;
 
     const prjPath = pkgPath.substring(0, pkgPath.lastIndexOf(path.sep));
-    return path.join(prjPath, pkgJson.bin['npm']);
+    return path.join(prjPath, pkgJson.bin['npx']);
   }
 
   /**
@@ -99,7 +94,7 @@ class NpmCommand {
    *
    * @private
    */
-  private static findNode(root?: string): string {
+  public static findNode(root?: string): string {
     const isExecutable = (filepath: string): boolean => {
       if (os.type() === 'Windows_NT') return filepath.endsWith('node.exe');
 
@@ -134,6 +129,22 @@ class NpmCommand {
       new SfError('Cannot locate node executable.', 'CannotFindNodeExecutable'),
       'CannotFindNodeExecutable'
     );
+  }
+
+  /**
+   * Returns the path to the npm-cli.js file in this package's node_modules
+   *
+   * @private
+   */
+  private static npmCli(): string {
+    const require = createRequire(import.meta.url);
+    const pkgPath = require.resolve('npm/package.json');
+
+    const fileData = fs.readFileSync(pkgPath, 'utf8');
+    const pkgJson = parseJson(fileData, pkgPath) as NpmPackage;
+
+    const prjPath = pkgPath.substring(0, pkgPath.lastIndexOf(path.sep));
+    return path.join(prjPath, pkgJson.bin['npm']);
   }
 
   /**

--- a/test/nuts/node-info.nut.ts
+++ b/test/nuts/node-info.nut.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+import path from 'node:path';
+import { expect } from 'chai';
+import { TestSession, execCmd } from '@salesforce/cli-plugins-testkit';
+import { Messages } from '@salesforce/core';
+import shelljs from 'shelljs';
+import { ensureObject } from '@salesforce/ts-types';
+import { NodeInfoResult } from '../../src/commands/node/info.js';
+
+Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
+describe('node info command', () => {
+  let session: TestSession;
+
+  before(async () => {
+    session = await TestSession.create({ devhubAuthStrategy: 'NONE' });
+    //
+    // ensure that this repo's version of the plugin is used and NOT the one that shipped with the CLI
+    execCmd('plugins link .', {
+      cwd: path.dirname(session.dir),
+      ensureExitCode: 0,
+      cli: 'sf',
+    });
+  });
+
+  after(async () => {
+    await session?.zip(undefined, 'artifacts');
+    try {
+      await session?.clean();
+    } catch (error) {
+      // ignore
+    }
+  });
+
+  it('should return node and npx paths and verify they work', () => {
+    // Get node and npx paths
+    const info = ensureObject<NodeInfoResult>(
+      execCmd('node info --json', {
+        ensureExitCode: 0,
+        // IMPORTANT: this NUT should run commands via `sf` to mimic real usage (node path being resolved from sf's rootPath)
+        // Do not make it run using `./bin/run.js`.
+        cli: 'sf',
+      }).jsonOutput?.result
+    );
+
+    expect(info.nodePath).to.be.a('string').and.not.empty;
+    expect(info.npxPath).to.be.a('string').and.not.empty;
+
+    // Verify node path works
+    const nodeHelp = shelljs.exec(`"${info.nodePath}" --help`, { silent: true });
+    expect(nodeHelp.code).to.equal(0);
+    expect(nodeHelp.stdout).to.contain('Usage: node');
+
+    // Verify npx path works
+    const npxHelp = shelljs.exec(`"${info.nodePath}" "${info.npxPath}" --help`, { silent: true });
+    expect(npxHelp.code).to.equal(0);
+    expect(npxHelp.stdout).to.contain('Run a command from a local or remote npm package');
+  });
+});


### PR DESCRIPTION
### What does this PR do?
Adds a hidden `node info` command that prints the path to the bundled node/npx files.
This will be used internally only by A4D.

It re-uses the same logic already in place for plugin signature verification to resolve the path to the bundled node binary (installers) or the global one (npm installs), which users have been using for years in mac/linux/windows.

### What issues does this PR fix or reference?
@W-18451508@